### PR TITLE
docs: rename, relink Quickstart

### DIFF
--- a/collections/_applications/quickstart.md
+++ b/collections/_applications/quickstart.md
@@ -1,14 +1,14 @@
 ---
 layout: home
 name: QUICKSTART
-title: DevOps Quickstart
+title: QuickStart for OpenShift
 version: ''
 order: 1
 description:
 ---
 
 
-The DevOps Quickstart is a fully functional set of pipeline workflows and a starter application stack intended to help agile DevOps teams hit the ground running. Currently OpenShift is supported with plans for AWS (Amazon Web Services). Pipelines are run using [GitHub Actions](https://github.com/bcgov/devops-quickstart/actions).
+The QuickStart for OpenShift is a fully functional set of pipeline workflows and a starter application stack intended to help agile DevOps teams hit the ground running. Currently OpenShift is supported with plans for AWS (Amazon Web Services). Pipelines are run using [GitHub Actions](https://github.com/bcgov/quickstart-openshift/actions).
 
 Features:
 - Pull Request-based pipeline
@@ -21,8 +21,8 @@ Features:
 - Templates and setup documentation
 - Starter TypeScript application stack
 
-This project is in active development.  Please visit our [issues](https://github.com/bcgov/devops-quickstart/issues) page to view or request features.
+This project is in active development.  Please visit our [issues](https://github.com/bcgov/quickstart-openshift/issues) page to view or request features.
 
 ## More information
-+ github: [https://github.com/bcgov/devops-quickstart/](https://github.com/bcgov/devops-quickstart/)
++ github: [https://github.com/bcgov/quickstart-openshift/](https://github.com/bcgov/quickstart-openshift/)
   


### PR DESCRIPTION
This pull request updates the DevOps Quickstart page on the FDS portal to refer to 'QuickStart for OpenShift', matching its modern branding and new repository path.